### PR TITLE
Return on error in the `getSheet` function

### DIFF
--- a/driveAPI.js
+++ b/driveAPI.js
@@ -125,7 +125,7 @@ class DriveAPI {
         spreadsheetId: id,
         range: range,
       }, (err, res) => {
-        if (err) reject('The API returned an error: ' + err);
+        if (err) return reject('The API returned an error: ' + err);
         // console.log(res.data.values);
         const keys = res.data.values[0];
         const transformed = [];


### PR DESCRIPTION
This commit ensures that all code paths that handle an error by calling the
reject function also return as they should. Only `getSheet` missed a return
statement, the other places were already good.

Closes issue #1.